### PR TITLE
Use RMR 1.1.0, same as bldr-alpine3:3-a3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # install a well known working rmr
 FROM python:3.7-alpine as builder
 RUN apk update && apk add autoconf automake build-base cmake libtool ninja pkgconfig git
-RUN git clone --branch 1.10.2 https://gerrit.o-ran-sc.org/r/ric-plt/lib/rmr \
+RUN git clone --branch 1.1.0 https://gerrit.o-ran-sc.org/r/ric-plt/lib/rmr \
     && cd rmr \
     && mkdir build \
     && cd build \

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     url="https://gerrit.o-ran-sc.org/r/admin/repos/ric-plt/a1",
     entry_points={"console_scripts": ["run.py=a1.run:main"]},
     # we require jsonschema, should be in that list, but connexion already requires a specific version of it
-    install_requires=["requests", "Flask", "connexion[swagger-ui]", "gevent", "rmr>=0.10.8"],
+    install_requires=["requests", "Flask", "connexion[swagger-ui]", "gevent", "rmr>=0.10.8,<=1.0.0"],
     package_data={"a1": ["openapi.yaml"]},
 )


### PR DESCRIPTION
AArch64 patching must align the RMR version cloned with the one
used in the old bldr-alpine:3-a3.9, set in ci-management repo.

Signed-off-by: Alexandru Avadanii <Alexandru.Avadanii@enea.com>